### PR TITLE
Master 7 organize cards based on the timeline indication in their name

### DIFF
--- a/scripts/trello/cards.js
+++ b/scripts/trello/cards.js
@@ -1,3 +1,9 @@
 async function postComment(cardId, text, { trelloApiKey, trelloOAuth1 } = {}) {
     return new TrelloClient({ trelloApiKey, trelloOAuth1 }).post(`cards/${cardId}/actions/comments`, { text });
 }
+async function getCard(cardId, { trelloApiKey, trelloOAuth1 } = {}) {
+    return new TrelloClient({ trelloApiKey, trelloOAuth1 }).get(`cards/${cardId}`);
+}
+async function updateCard(cardId, { pos }, { trelloApiKey, trelloOAuth1 } = {}) {
+    return new TrelloClient({ trelloApiKey, trelloOAuth1 }).put(`cards/${cardId}`, { pos });
+}

--- a/scripts/trello/lists.js
+++ b/scripts/trello/lists.js
@@ -1,0 +1,3 @@
+async function fetchCardsInList(listId, { trelloApiKey, trelloOAuth1 } = {}) {
+    return new TrelloClient({ trelloApiKey, trelloOAuth1 }).get(`lists/${listId}/cards`);
+}

--- a/scripts/trelloOnboardingBuilder.js
+++ b/scripts/trelloOnboardingBuilder.js
@@ -6,56 +6,44 @@ const includeCommand = "/targetfor";
 //const basicsCardsSuffix = "basics";
 const basicsCardsSuffix = "my toto test";
 
-async function includeBasics() {
-    document.getElementById("message").innerText = "Including basics cards...";
-    const allCardsOnCuPaths = await fetchCardsOnBoard(getHrCuPathsBoardId(), { trelloApiKey: getTrelloApiKey(), trelloOAuth1: getTrelloOAuth1() });
-    const allBasicsCardIds = allCardsOnCuPaths
-        .filter(({ name }) => name.trim().toLowerCase().endsWith(basicsCardsSuffix))
-        .map(({ shortLink }) => shortLink);
-    const commentText = `${includeCommand} ${getLearningPathCard()}`;
-    for (const cardId of allBasicsCardIds) {
-        await postComment(cardId, commentText, { trelloApiKey: getTrelloApiKey(), trelloOAuth1: getTrelloOAuth1() })
-    }
-    document.getElementById("message").innerText = `Including ${allBasicsCardIds.length} basics cards with success!`;
-}
-function organizeLearningPath() {
-    document.getElementById("message").innerText = "Not yet available, please be patient :)";
-}
-
-function getHrCuPathsBoardId() {
-    const hrCuPathsBoard = getHrCuPathsBoard();
-    if (! hrCuPathsBoard) { return ""; }
-
-    const boardIdRegex = /https:\/\/trello\.com\/b\/([^\/]+)\/.*/;
-    const boardIdRegexMatches = boardIdRegex.exec(hrCuPathsBoard);
-    if (! boardIdRegexMatches) { return ""; }
-
-    return boardIdRegexMatches[1];
-}
-function getTrelloApiKey() {
-    return document.getElementById("trelloApiKey").value;
-}
-function getTrelloOAuth1() {
-    return document.getElementById("trelloOAuth1").value;
-}
-function getHrCuPathsBoard() {
-    return document.getElementById("hrCuPathsBoard").value;
-}
-function getLearningPathCard() {
-    return document.getElementById("learningPathCard").value;
-}
-
 var app = new Vue({
     el: '#app',
     data: {
         trelloApiKey: "",
         trelloOAuth1: "",
         hrCuPathsBoard: "https://trello.com/b/uKPiQQ7R/hr-cu-paths",
-        learningPathCard: ""
+        learningPathCard: "",
+        message: ""
     },
     computed: {
         isValid() {
             return !! this.trelloApiKey && !! this.trelloOAuth1 && !! this.hrCuPathsBoard && !! this.learningPathCard;
+        },
+        hrCuPathsBoardId() {
+            if (! this.hrCuPathsBoard) { return ""; }
+
+            const boardIdRegex = /https:\/\/trello\.com\/b\/([^\/]+)\/.*/;
+            const boardIdRegexMatches = boardIdRegex.exec(this.hrCuPathsBoard);
+            if (! boardIdRegexMatches) { return ""; }
+
+            return boardIdRegexMatches[1];
+        },
+    },
+    methods: {
+        async includeBasics() {
+            this.message = "Including basics cards...";
+            const allCardsOnCuPaths = await fetchCardsOnBoard(this.hrCuPathsBoardId, { trelloApiKey: this.trelloApiKey, trelloOAuth1: this.trelloOAuth1 });
+            const allBasicsCardIds = allCardsOnCuPaths
+                .filter(({ name }) => name.trim().toLowerCase().endsWith(basicsCardsSuffix))
+                .map(({ shortLink }) => shortLink);
+            const commentText = `${includeCommand} ${this.learningPathCard}`;
+            for (const cardId of allBasicsCardIds) {
+                await postComment(cardId, commentText, { trelloApiKey: this.trelloApiKey, trelloOAuth1: this.trelloOAuth1 })
+            }
+            this.message = `Including ${allBasicsCardIds.length} basics cards with success!`;
+        },
+        organizeLearningPath() {
+            this.message = "Not yet available, please be patient :)";
         }
     }
 });

--- a/scripts/trelloOnboardingBuilder.js
+++ b/scripts/trelloOnboardingBuilder.js
@@ -28,6 +28,15 @@ var app = new Vue({
 
             return boardIdRegexMatches[1];
         },
+        learningPathCardId() {
+            if (! this.learningPathCard) { return ""; }
+
+            const cardIdRegex = /https:\/\/trello\.com\/c\/([^\/]+)\/.*/;
+            const cardIdRegexMatches = cardIdRegex.exec(this.learningPathCard);
+            if (! cardIdRegexMatches) { return ""; }
+
+            return cardIdRegexMatches[1];
+        },
     },
     methods: {
         async includeBasics() {
@@ -42,8 +51,10 @@ var app = new Vue({
             }
             this.message = `Including ${allBasicsCardIds.length} basics cards with success!`;
         },
-        organizeLearningPath() {
-            this.message = "Not yet available, please be patient :)";
+        async organizeLearningPath() {
+            this.message = "Reorganizing Learning Path...";
+            const { idList: learningPathListId } = await getCard(this.learningPathCardId, { trelloApiKey: this.trelloApiKey, trelloOAuth1: this.trelloOAuth1 });
+            const allCardsInLearningPath = await fetchCardsInList(learningPathListId, { trelloApiKey: this.trelloApiKey, trelloOAuth1: this.trelloOAuth1 });
         }
     }
 });

--- a/scripts/trelloOnboardingBuilder.js
+++ b/scripts/trelloOnboardingBuilder.js
@@ -6,6 +6,23 @@ const includeCommand = "/targetfor";
 //const basicsCardsSuffix = "basics";
 const basicsCardsSuffix = "my toto test";
 
+const timelineInformationMapping = {
+    "DAY 1": 0,
+    "DAY 2": 1,
+    "DAY 3": 2,
+    "DAY 4": 3,
+    "DAY 5": 4,
+    "WEEK 1": 5,
+    "WEEK 2": 6,
+    "WEEK 3": 7,
+    "WEEK 4": 8,
+    "WEEK 5": 9,
+    "MONTH 1": 10,
+    "MONTH 2": 11,
+    "MONTH 3": 12,
+    "MONTH 4": 13
+};
+
 var app = new Vue({
     el: '#app',
     data: {
@@ -55,6 +72,17 @@ var app = new Vue({
             this.message = "Reorganizing Learning Path...";
             const { idList: learningPathListId } = await getCard(this.learningPathCardId, { trelloApiKey: this.trelloApiKey, trelloOAuth1: this.trelloOAuth1 });
             const allCardsInLearningPath = await fetchCardsInList(learningPathListId, { trelloApiKey: this.trelloApiKey, trelloOAuth1: this.trelloOAuth1 });
+            const initialTimelineCardPosition = computeInitialTimelineCardPositions();
+
+            function computeInitialTimelineCardPositions() {
+                const timelineCardPosition = {};
+                for (const card of allCardsInLearningPath) {
+                    if (! Object.keys(timelineInformationMapping).includes(card.name)) { continue; }
+
+                    timelineCardPosition[timelineInformationMapping[card.name]] = card.pos;
+                }
+                return timelineCardPosition;
+            }
         }
     }
 });

--- a/trelloOnboardingBuilder.html
+++ b/trelloOnboardingBuilder.html
@@ -67,6 +67,7 @@
 <script src="./scripts/trello/api.js"></script>
 <script src="./scripts/trello/boards.js"></script>
 <script src="./scripts/trello/cards.js"></script>
+<script src="./scripts/trello/lists.js"></script>
 <script src="./scripts/trelloOnboardingBuilder.js"></script>
 </body>
 </html>

--- a/trelloOnboardingBuilder.html
+++ b/trelloOnboardingBuilder.html
@@ -50,13 +50,13 @@
             </div>
             <br>
             <h1>3 - Let the magic happen</h1>
-            <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" onclick="includeBasics()">
+            <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" @click="includeBasics()">
                 1 - Include the "basics" modules into the Learning Path
             </button>
-            <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" onclick="organizeLearningPath()">
+            <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" @click="organizeLearningPath()">
                 2 - Automatically organize the Learning Path modules that have an indicated timeline
             </button>
-            <div id="message"></div>
+            <div id="message">{{ message }}</div>
         </div>
         <br>
     </div>

--- a/trelloOnboardingBuilder.html
+++ b/trelloOnboardingBuilder.html
@@ -56,7 +56,7 @@
             <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" @click="organizeLearningPath()">
                 2 - Automatically organize the Learning Path modules that have an indicated timeline
             </button>
-            <div id="message">{{ message }}</div>
+            <div>{{ message }}</div>
         </div>
         <br>
     </div>


### PR DESCRIPTION
https://github.com/360Learning/360learning.github.io/issues/7

## Context
Here is where magic is happening again: all the cards in the Trello Learning Path list that have an indication of the timeline in their name are moved to the correct place 😍 (in the coming ticket, I will also rename them to remove this time indication)

And here is a video of the result of reorganizing the cards
https://www.loom.com/share/bdeb1dfc9b9747b38614fd4f7e81b80b

## Changes
First, I do some cleaning, because shitty code is not code I like 💩 

And after this, I go through all the cards of the Learning Path list (based on the readme card input), and for all those that have a timeline information, I compute the position where they should go