### PR TITLE
Master 8 rename the reorganized cards

### DIFF
--- a/scripts/trello/cards.js
+++ b/scripts/trello/cards.js
@@ -4,6 +4,6 @@ async function postComment(cardId, text, { trelloApiKey, trelloOAuth1 } = {}) {
 async function getCard(cardId, { trelloApiKey, trelloOAuth1 } = {}) {
     return new TrelloClient({ trelloApiKey, trelloOAuth1 }).get(`cards/${cardId}`);
 }
-async function updateCard(cardId, { pos }, { trelloApiKey, trelloOAuth1 } = {}) {
-    return new TrelloClient({ trelloApiKey, trelloOAuth1 }).put(`cards/${cardId}`, { pos });
+async function updateCard(cardId, { name, pos }, { trelloApiKey, trelloOAuth1 } = {}) {
+    return new TrelloClient({ trelloApiKey, trelloOAuth1 }).put(`cards/${cardId}`, { name, pos });
 }

--- a/scripts/trelloOnboardingBuilder.js
+++ b/scripts/trelloOnboardingBuilder.js
@@ -3,8 +3,7 @@ String.prototype.cleanup = function() {
 };
 
 const includeCommand = "/targetfor";
-//const basicsCardsSuffix = "basics";
-const basicsCardsSuffix = "my toto test";
+const basicsCardsSuffix = "basics";
 
 const timelineInformationMapping = {
     "DAY 1": 0,

--- a/scripts/trelloOnboardingBuilder.js
+++ b/scripts/trelloOnboardingBuilder.js
@@ -88,7 +88,12 @@ var app = new Vue({
                 for (const cardWithTimelineInformation of cardsToReorganizeWithTimelineInformation) {
                     const expectedCardPositionInList = timelineCardPosition[cardWithTimelineInformation.timelineInformationIndex] + 1;
                     incrementPositionsForTimelineInformationAfter(cardWithTimelineInformation.timelineInformationIndex, timelineCardPosition);
-                    await updateCard(cardWithTimelineInformation.id, { pos: expectedCardPositionInList }, { trelloApiKey, trelloOAuth1 });
+                    const nameWithoutTimelineInformation = removeTimelineInformation(cardWithTimelineInformation.name);
+                    await updateCard(
+                        cardWithTimelineInformation.id,
+                        { name: nameWithoutTimelineInformation, pos: expectedCardPositionInList },
+                        { trelloApiKey, trelloOAuth1 }
+                    );
                 }
                 return cardsToReorganizeWithTimelineInformation.length;
 
@@ -126,6 +131,10 @@ var app = new Vue({
 
                     timelineCardPosition[index]++;
                 }
+            }
+            function removeTimelineInformation(name) {
+                const timelineInformationRegex = /(.+)\[(DAY|WEEK|MONTH) \d]/;
+                return timelineInformationRegex.exec(name)[1].trim();
             }
         }
     }

--- a/trelloOnboardingBuilder.html
+++ b/trelloOnboardingBuilder.html
@@ -53,9 +53,13 @@
             <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" @click="includeBasics()">
                 1 - Include the "basics" modules into the Learning Path
             </button>
+            <p>2 - Include the modules that are related to the newcomer's function. In the future, this might be automated as well (be patient ^^), but right now it's still a manual action.
+                <br>Don't forget to wait for each of these modules to be included in the Learning Path before applying the next step of magic below :)
+            </p>
             <button class="button wide with-margin" :class="{ disabled: ! isValid }" :disabled="! isValid" @click="organizeLearningPath()">
-                2 - Automatically organize the Learning Path modules that have an indicated timeline
+                3 - Automatically organize the Learning Path modules that have an indicated timeline
             </button>
+            <p>4 - Manually organize the modules that didn't have an indicated timeline.</p>
             <div>{{ message }}</div>
         </div>
         <br>


### PR DESCRIPTION
https://github.com/360Learning/360learning.github.io/issues/8

## Context
Here is the last part of this MVP: in addition to moving the cards, the idea is also to rename them to have them clean (i.e. without the timeline indication anymore)

And here is a video of the result of reorganizing the cards
https://www.loom.com/share/38c1bba6ed3e4bcf94202d78d0eda558

## Changes
In addition to the quite straightforward fix, I also add some text to help the onboarders use this tool to its best extent
I also remove the "security" I put in place => it's now usable in real life 🎉 