### PR TITLE
Create a page to visualize Trello comments of a user

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
             <button onclick="location.href='trelloOnboardingBuilder.html'" class="tool">
                 Trello board building helper for new joiners
             </button>
+            <button onclick="location.href='trelloCommentsDashboard.html'" class="tool">
+                Trello comments dashboard
+            </button>
         </div>
     </div>
 </div>

--- a/scripts/trello/actions.js
+++ b/scripts/trello/actions.js
@@ -1,0 +1,9 @@
+async function fetchUserComments(memberId, options, credentials) {
+    const client = new TrelloClient(credentials);
+    return client.get(`members/${memberId}/actions`, {
+        filter: "commentCard",
+        member: false,
+        memberCreator: false,
+        ...options
+    });
+}

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -17,6 +17,7 @@ new Vue({
                 HRCUPaths: true,
                 zConvexity: true
             },
+            truncationLength: 5
         },
         error: null,
         sort: { field: "date", ascending: false },
@@ -82,7 +83,7 @@ function parseComments(comments, options) {
             board: comment.data.board.name,
             card: comment.data.card.name,
             date: comment.date.slice(0, 10),
-            text: buildCommentText(comment.data.text),
+            text: buildCommentText(comment.data.text, options.truncationLength),
             link: buildLinkToComment(comment)
         };
     }
@@ -95,8 +96,15 @@ function getStartOfCurrentQuarter() {
     return moment().startOf("quarter").format("YYYY-MM-DD");
 }
 
-function buildCommentText(markdown) {
-    return markdownit().render(markdown);
+function buildCommentText(markdown, truncationLength) {
+    return markdownit().render(buildTruncatedText());
+
+    function buildTruncatedText() {
+        if (! truncationLength) { return markdown; }
+        const lines = markdown.split("\n");
+        if (lines.length <= truncationLength) { return markdown; }
+        return markdown.split("\n").slice(0, truncationLength).join("\n") + "\n\n[...]";
+    }
 }
 function buildLinkToComment(comment) {
     return `${TRELLO_BASE_URL}/c/${comment.data.card.shortLink}#action-${comment.id}`;

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -54,12 +54,15 @@ function parseComments(comments) {
             board: comment.data.board.name,
             card: comment.data.card.name,
             date: comment.date.slice(0, 10),
-            text: comment.data.text,
+            text: buildCommentText(comment.data.text),
             link: buildLinkToComment(comment)
         };
     }
 }
 
+function buildCommentText(markdown) {
+    return markdownit().render(markdown);
+}
 function buildLinkToComment(comment) {
     return `${TRELLO_BASE_URL}/c/${comment.data.card.shortLink}#action-${comment.id}`;
 }

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -20,6 +20,7 @@ new Vue({
             truncationLength: 5
         },
         error: null,
+        loading: false,
         sort: { field: "date", ascending: false },
         trelloCredentialsHelperFile: TRELLO_CREDENTIALS_HELPER_FILE,
         credentials: {
@@ -29,6 +30,9 @@ new Vue({
         username: ""
     },
     computed: {
+        isSubmitButtonDisabled() {
+            return ! this.isValid || this.loading;
+        },
         isValid() {
             return !! this.credentials.trelloApiKey && !! this.credentials.trelloOAuth1 && !! this.username;
         }
@@ -44,12 +48,15 @@ new Vue({
         async fetchComments() {
             this.comments = null;
             this.error = null;
+            this.loading = true;
             try {
                 const comments = await fetchUserComments(this.username, this.buildOptions(), this.credentials);
                 this.comments = parseComments(comments, this.options);
                 this.sortComments();
             } catch (error) {
                 this.error = error.message;
+            } finally {
+                this.loading = false;
             }
         },
         sortComments() {

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -6,6 +6,7 @@ new Vue({
     data: {
         comments: null,
         error: null,
+        sort: { field: "date", ascending: false },
         trelloCredentialsHelperFile: TRELLO_CREDENTIALS_HELPER_FILE,
         credentials: {
             trelloApiKey: "",
@@ -25,9 +26,21 @@ new Vue({
             try {
                 const comments = await fetchUserComments(this.username, {}, this.credentials);
                 this.comments = parseComments(comments);
+                this.sortComments();
             } catch (error) {
                 this.error = error.message;
             }
+        },
+        sortComments() {
+            const field = this.sort.field;
+            const ascendingFactor = this.sort.ascending ? 1 : -1;
+            this.comments.sort((comment1, comment2) => {
+                return comment1[field].localeCompare(comment2[field]) * ascendingFactor;
+            });
+        },
+        updateSort(sort) {
+            this.sort = sort;
+            this.sortComments();
         }
     }
 });

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -1,9 +1,11 @@
+const TRELLO_BASE_URL = "https://trello.com";
 const TRELLO_CREDENTIALS_HELPER_FILE = "https://docs.google.com/document/d/1HwaedNa861gkj93TaradW5n0MID8cbeamiU5SXCvX64/edit#heading=h.ijjo2dol5z6v"
 
 new Vue({
     el: '#app',
     data: {
         comments: null,
+        error: null,
         trelloCredentialsHelperFile: TRELLO_CREDENTIALS_HELPER_FILE,
         credentials: {
             trelloApiKey: "",
@@ -18,7 +20,33 @@ new Vue({
     },
     methods: {
         async fetchComments() {
-            this.comments = [];
+            this.comments = null;
+            this.error = null;
+            try {
+                const comments = await fetchUserComments(this.username, {}, this.credentials);
+                this.comments = parseComments(comments);
+            } catch (error) {
+                this.error = error.message;
+            }
         }
     }
 });
+
+function parseComments(comments) {
+    return comments
+        .map(parseComment);
+
+    function parseComment(comment) {
+        return {
+            board: comment.data.board.name,
+            card: comment.data.card.name,
+            date: comment.date.slice(0, 10),
+            text: comment.data.text,
+            link: buildLinkToComment(comment)
+        };
+    }
+}
+
+function buildLinkToComment(comment) {
+    return `${TRELLO_BASE_URL}/c/${comment.data.card.shortLink}#action-${comment.id}`;
+}

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -21,6 +21,7 @@ new Vue({
         },
         error: null,
         loading: false,
+        search: "",
         sort: { field: "date", ascending: false },
         trelloCredentialsHelperFile: TRELLO_CREDENTIALS_HELPER_FILE,
         credentials: {
@@ -30,6 +31,17 @@ new Vue({
         username: ""
     },
     computed: {
+        filteredComments() {
+            const search = this.search.toLowerCase();
+
+            return this.comments.filter(comment => {
+                return (
+                    comment.board.toLowerCase().includes(search) ||
+                    comment.card.toLowerCase().includes(search) ||
+                    comment.originalText.toLowerCase().includes(search)
+                );
+            });
+        },
         isSubmitButtonDisabled() {
             return ! this.isValid || this.loading;
         },
@@ -90,6 +102,7 @@ function parseComments(comments, options) {
             board: comment.data.board.name,
             card: comment.data.card.name,
             date: comment.date.slice(0, 10),
+            originalText: comment.data.text,
             text: buildCommentText(comment.data.text, options.truncationLength),
             link: buildLinkToComment(comment)
         };

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -1,0 +1,24 @@
+const TRELLO_CREDENTIALS_HELPER_FILE = "https://docs.google.com/document/d/1HwaedNa861gkj93TaradW5n0MID8cbeamiU5SXCvX64/edit#heading=h.ijjo2dol5z6v"
+
+new Vue({
+    el: '#app',
+    data: {
+        comments: null,
+        trelloCredentialsHelperFile: TRELLO_CREDENTIALS_HELPER_FILE,
+        credentials: {
+            trelloApiKey: "",
+            trelloOAuth1: ""
+        },
+        username: ""
+    },
+    computed: {
+        isValid() {
+            return !! this.credentials.trelloApiKey && !! this.credentials.trelloOAuth1 && !! this.username;
+        }
+    },
+    methods: {
+        async fetchComments() {
+            this.comments = [];
+        }
+    }
+});

--- a/signatureGenerator.html
+++ b/signatureGenerator.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" type="text/css" href="./style/style.css">
 </head>
 <body>
-<div>
 <div id="app" @contextmenu="preventBadCopy">
     <div id="header">
         <div class="container">
@@ -139,7 +138,6 @@
         </div>
         <br>
     </div>
-</div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 <!--<script src="https://cdn.jsdelivr.net/npm/vue"></script>-->

--- a/style/style.css
+++ b/style/style.css
@@ -90,7 +90,7 @@ html, body
 .field-name
 {
     display: inline-block;
-    width: 150px;
+    width: 250px;
     font-size: 13px;
     font-weight: 600;
 }

--- a/style/style.css
+++ b/style/style.css
@@ -99,10 +99,13 @@ input, select
 {
     padding: 9px;
     border: 1px solid #eeeeee;
-    width: 340px;
     border-radius: 4px;
     margin: 2px 0;
     box-sizing: border-box;
+}
+
+input:not([type=checkbox]) {
+    width: 340px;
 }
 
 input:focus, select:focus

--- a/style/trelloCommentsDashboard.css
+++ b/style/trelloCommentsDashboard.css
@@ -28,6 +28,10 @@ td {
     width: 200px;
 }
 
+.rendered-markdown p {
+    font-size: inherit;
+}
+
 .sorting-arrows {
     float: right;
 }

--- a/style/trelloCommentsDashboard.css
+++ b/style/trelloCommentsDashboard.css
@@ -1,3 +1,7 @@
+.direction-column {
+    flex-direction: column;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;

--- a/style/trelloCommentsDashboard.css
+++ b/style/trelloCommentsDashboard.css
@@ -1,0 +1,29 @@
+table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout:fixed;
+}
+
+table, th, td {
+    border: 1px solid;
+    padding: 8px;
+}
+
+td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: normal;
+    overflow-wrap: anywhere;
+}
+
+.column-date {
+    width: 100px;
+}
+
+.column-board {
+    width: 200px;
+}
+
+.column-card {
+    width: 200px;
+}

--- a/style/trelloCommentsDashboard.css
+++ b/style/trelloCommentsDashboard.css
@@ -27,3 +27,11 @@ td {
 .column-card {
     width: 200px;
 }
+
+.sorting-arrows {
+    float: right;
+}
+
+.sorting-arrows > span {
+    cursor: pointer;
+}

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -107,7 +107,10 @@
                         </template>
 
                         <div v-if="comments">
-                            <h2>Results ({{ comments.length }} comments found)</h2>
+                            <h2>Results ({{ filteredComments.length }} comments found)</h2>
+
+                            <input id="search" type="text" placeholder="Filter results" v-model="search">
+                            <hr>
 
                             <table>
                                 <thead>
@@ -137,7 +140,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr v-for="comment in comments">
+                                    <tr v-for="comment in filteredComments">
                                         <td>{{ comment.date }}</td>
                                         <td>{{ comment.board }}</td>
                                         <td><a :href="comment.link" target="_blank">{{ comment.card }}</a></td>

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -75,12 +75,24 @@
                                     <tr>
                                         <th class="column-date">
                                             Date
+                                            <div class="sorting-arrows">
+                                                <span @click="updateSort({ field: 'date', ascending: true })">⬆️</span>
+                                                <span @click="updateSort({ field: 'date', ascending: false })">⬇️</span>
+                                            </div>
                                         </th>
                                         <th class="column-card">
                                             Board
+                                            <div class="sorting-arrows">
+                                                <span @click="updateSort({ field: 'board', ascending: true })">⬆️</span>
+                                                <span @click="updateSort({ field: 'board', ascending: false })">⬇️</span>
+                                            </div>
                                         </th>
                                         <th class="column-card">
                                             Card
+                                            <div class="sorting-arrows">
+                                                <span @click="updateSort({ field: 'card', ascending: true })">⬆️</span>
+                                                <span @click="updateSort({ field: 'card', ascending: false })">⬇️</span>
+                                            </div>
                                         </th>
                                         <th class="column-comment">Comment</th>
                                     </tr>

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -31,7 +31,7 @@
 
                         <hr>
 
-                        <div class="form-wrapper">
+                        <div class="form-wrapper direction-column">
                             <div class="form-field">
                                 <label for="trelloApiKey" class="field-name">Trello identifier:</label>
                                 <input id="trelloApiKey" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloApiKey">
@@ -43,6 +43,39 @@
                             <div class="form-field">
                                 <label for="username" class="field-name">Your colleague's username:</label>
                                 <input id="username" type="text" placeholder="thomasrice" v-model="username" @keyup.enter="fetchComments()">
+                            </div>
+
+                            <h2>Settings</h2>
+
+                            <div class="form-field">
+                                <label for="since" class="field-name">Start date</label>
+                                <input id="since" type="date" placeholder="YYYY-MM-DD" v-model="options.since">
+                                <span>(included)</span>
+                            </div>
+                            <div class="form-field">
+                                <label for="before" class="field-name">End date</label>
+                                <input id="before" type="date" placeholder="YYYY-MM-DD" v-model="options.before">
+                                <span>(excluded)</span>
+                            </div>
+                            <div class="form-field">
+                                <label for="limit" class="field-name">Limit to N comments?</label>
+                                <input id="limit" type="number" placeholder="100" v-model="options.limit">
+                                <span>(1000 is the maximum allowed by Trello)</span>
+                            </div>
+                            <br>
+                            <div class="form-field">
+                                <input id="excludeScopes" type="checkbox" v-model="options.excludedBoards.scopes">
+                                <label for="excludeScopes" class="field-name">Exclude <em>Scopes</em> board?</label>
+                            </div>
+                            <br>
+                            <div class="form-field">
+                                <input id="excludeHRCUPaths" type="checkbox" v-model="options.excludedBoards.HRCUPaths">
+                                <label for="excludeHRCUPaths" class="field-name">Exclude <em>HR: CU Paths</em> board?</label>
+                            </div>
+                            <br>
+                            <div class="form-field">
+                                <input id="excludeZConvexity" type="checkbox" v-model="options.excludedBoards.zConvexity">
+                                <label for="excludeZConvexity" class="field-name">Exclude <em>zConvexity</em> boards?</label>
                             </div>
                         </div>
                         <br>
@@ -116,6 +149,7 @@
         <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/12.3.2/markdown-it.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.3/moment.min.js"></script>
         <script src="./scripts/trello/api.js"></script>
         <script src="./scripts/trello/actions.js"></script>
         <script src="./scripts/trelloCommentsDashboard.js"></script>

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -86,11 +86,12 @@
                         <br>
                         <button
                                 class="button wide"
-                                :class="{ disabled: ! isValid }"
-                                :disabled="! isValid"
+                                :class="{ disabled: isSubmitButtonDisabled }"
+                                :disabled="isSubmitButtonDisabled"
                                 @click="fetchComments()"
                         >
-                            Fetch comments
+                            <template v-if="loading">Fetching comments...</template>
+                            <template v-else>Fetch comments</template>
                         </button>
                         <br>
 

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8">
         <title>360Tools - Trello comments dashboard</title>
         <link rel="stylesheet" type="text/css" href="./style/style.css">
+        <link rel="stylesheet" type="text/css" href="./style/trelloCommentsDashboard.css">
     </head>
     <body>
         <div>
@@ -53,6 +54,47 @@
                         >
                             Fetch comments
                         </button>
+                        <br>
+
+                        <template v-if="error">
+                            An error occurred: <strong>{{ error }}</strong>
+                            <br>
+                            <template v-if="error.includes('404')">
+                                The username you entered may be incorrect.
+                            </template>
+                            <template v-else-if="error.includes('401')">
+                                The identifier or token you entered may be incorrect.
+                            </template>
+                        </template>
+
+                        <div v-if="comments">
+                            <h2>Results ({{ comments.length }} comments found)</h2>
+
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th class="column-date">
+                                            Date
+                                        </th>
+                                        <th class="column-card">
+                                            Board
+                                        </th>
+                                        <th class="column-card">
+                                            Card
+                                        </th>
+                                        <th class="column-comment">Comment</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr v-for="comment in comments">
+                                        <td>{{ comment.date }}</td>
+                                        <td>{{ comment.board }}</td>
+                                        <td><a :href="comment.link" target="_blank">{{ comment.card }}</a></td>
+                                        <td v-html="comment.text"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
                     <br>
                 </div>
@@ -60,6 +102,9 @@
         </div>
 
         <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+        <script src="./scripts/trello/api.js"></script>
+        <script src="./scripts/trello/actions.js"></script>
         <script src="./scripts/trelloCommentsDashboard.js"></script>
     </body>
 </html>

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>360Tools - Trello comments dashboard</title>
+        <link rel="stylesheet" type="text/css" href="./style/style.css">
+    </head>
+    <body>
+        <div>
+            <div id="app">
+                <div id="header">
+                    <div class="container">
+                        <a id="logo" href="index.html">360Tools</a>
+                    </div>
+                </div>
+                <div class="container">
+                    <h1>Trello comments dashboard</h1>
+
+
+                    <div class="element form">
+
+                        It's Performance Reviews time, and you want to see all the comments made by your reviewee during the period? 🕵️
+                        <br>You're desperately looking for a comment made by someone in particular, but the Trello search won't let you find it? 👺
+
+                        <hr>
+
+                        <br>To get started, get your <a target="_blank" :href="trelloCredentialsHelperFile">Trello API information</a> and store carefully your identifier and authentication token.
+                        <br>This tool will fetch your colleague's Trello comments on your behalf.
+                        <br>Don't worry, the information will not be stored by this website in any way.
+
+                        <hr>
+
+                        <div class="form-wrapper">
+                            <div class="form-field">
+                                <label for="trelloApiKey" class="field-name">Trello identifier:</label>
+                                <input id="trelloApiKey" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloApiKey">
+                            </div>
+                            <div class="form-field">
+                                <label for="trelloOAuth1" class="field-name">Authentication token:</label>
+                                <input id="trelloOAuth1" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloOAuth1">
+                            </div>
+                            <div class="form-field">
+                                <label for="username" class="field-name">Your colleague's username:</label>
+                                <input id="username" type="text" placeholder="thomasrice" v-model="username" @keyup.enter="fetchComments()">
+                            </div>
+                        </div>
+                        <br>
+                        <button
+                                class="button wide"
+                                :class="{ disabled: ! isValid }"
+                                :disabled="! isValid"
+                                @click="fetchComments()"
+                        >
+                            Fetch comments
+                        </button>
+                    </div>
+                    <br>
+                </div>
+            </div>
+        </div>
+
+        <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+        <script src="./scripts/trelloCommentsDashboard.js"></script>
+    </body>
+</html>

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -7,151 +7,149 @@
         <link rel="stylesheet" type="text/css" href="./style/trelloCommentsDashboard.css">
     </head>
     <body>
-        <div>
-            <div id="app">
-                <div id="header">
-                    <div class="container">
-                        <a id="logo" href="index.html">360Tools</a>
-                    </div>
-                </div>
+        <div id="app">
+            <div id="header">
                 <div class="container">
-                    <h1>Trello comments dashboard</h1>
+                    <a id="logo" href="index.html">360Tools</a>
+                </div>
+            </div>
+            <div class="container">
+                <h1>Trello comments dashboard</h1>
 
 
-                    <div class="element form">
+                <div class="element form">
 
-                        It's Performance Reviews time, and you want to see all the comments made by your reviewee during the period? 🕵️
-                        <br>You're desperately looking for a comment made by someone in particular, but the Trello search won't let you find it? 👺
+                    It's Performance Reviews time, and you want to see all the comments made by your reviewee during the period? 🕵️
+                    <br>You're desperately looking for a comment made by someone in particular, but the Trello search won't let you find it? 👺
 
-                        <hr>
+                    <hr>
 
-                        <br>To get started, get your <a target="_blank" :href="trelloCredentialsHelperFile">Trello API information</a> and store carefully your identifier and authentication token.
-                        <br>This tool will fetch your colleague's Trello comments on your behalf.
-                        <br>Don't worry, the information will not be stored by this website in any way.
+                    <br>To get started, get your <a target="_blank" :href="trelloCredentialsHelperFile">Trello API information</a> and store carefully your identifier and authentication token.
+                    <br>This tool will fetch your colleague's Trello comments on your behalf.
+                    <br>Don't worry, the information will not be stored by this website in any way.
 
-                        <hr>
+                    <hr>
 
-                        <div class="form-wrapper direction-column">
-                            <div class="form-field">
-                                <label for="trelloApiKey" class="field-name">Trello identifier:</label>
-                                <input id="trelloApiKey" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloApiKey">
-                            </div>
-                            <div class="form-field">
-                                <label for="trelloOAuth1" class="field-name">Authentication token:</label>
-                                <input id="trelloOAuth1" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloOAuth1">
-                            </div>
-                            <div class="form-field">
-                                <label for="username" class="field-name">Your colleague's username:</label>
-                                <input id="username" type="text" placeholder="thomasrice" v-model="username" @keyup.enter="fetchComments()">
-                            </div>
+                    <div class="form-wrapper direction-column">
+                        <div class="form-field">
+                            <label for="trelloApiKey" class="field-name">Trello identifier:</label>
+                            <input id="trelloApiKey" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloApiKey">
+                        </div>
+                        <div class="form-field">
+                            <label for="trelloOAuth1" class="field-name">Authentication token:</label>
+                            <input id="trelloOAuth1" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloOAuth1">
+                        </div>
+                        <div class="form-field">
+                            <label for="username" class="field-name">Your colleague's username:</label>
+                            <input id="username" type="text" placeholder="thomasrice" v-model="username" @keyup.enter="fetchComments()">
+                        </div>
 
-                            <h2>Settings</h2>
+                        <h2>Settings</h2>
 
-                            <div class="form-field">
-                                <label for="since" class="field-name">Start date</label>
-                                <input id="since" type="date" placeholder="YYYY-MM-DD" v-model="options.since">
-                                <span>(included)</span>
-                            </div>
-                            <div class="form-field">
-                                <label for="before" class="field-name">End date</label>
-                                <input id="before" type="date" placeholder="YYYY-MM-DD" v-model="options.before">
-                                <span>(excluded)</span>
-                            </div>
-                            <div class="form-field">
-                                <label for="limit" class="field-name">Limit to N comments?</label>
-                                <input id="limit" type="number" placeholder="100" v-model="options.limit">
-                                <span>(1000 is the maximum allowed by Trello)</span>
-                            </div>
-                            <div class="form-field">
-                                <label for="truncationLength" class="field-name">Truncate comments to N lines?</label>
-                                <input id="truncationLength" type="number" placeholder="5" v-model="options.truncationLength">
-                                <span>(Leave empty to display the full comments)</span>
-                            </div>
-                            <br>
-                            <div class="form-field">
-                                <input id="excludeScopes" type="checkbox" v-model="options.excludedBoards.scopes">
-                                <label for="excludeScopes" class="field-name">Exclude <em>Scopes</em> board?</label>
-                            </div>
-                            <br>
-                            <div class="form-field">
-                                <input id="excludeHRCUPaths" type="checkbox" v-model="options.excludedBoards.HRCUPaths">
-                                <label for="excludeHRCUPaths" class="field-name">Exclude <em>HR: CU Paths</em> board?</label>
-                            </div>
-                            <br>
-                            <div class="form-field">
-                                <input id="excludeZConvexity" type="checkbox" v-model="options.excludedBoards.zConvexity">
-                                <label for="excludeZConvexity" class="field-name">Exclude <em>zConvexity</em> boards?</label>
-                            </div>
+                        <div class="form-field">
+                            <label for="since" class="field-name">Start date</label>
+                            <input id="since" type="date" placeholder="YYYY-MM-DD" v-model="options.since">
+                            <span>(included)</span>
+                        </div>
+                        <div class="form-field">
+                            <label for="before" class="field-name">End date</label>
+                            <input id="before" type="date" placeholder="YYYY-MM-DD" v-model="options.before">
+                            <span>(excluded)</span>
+                        </div>
+                        <div class="form-field">
+                            <label for="limit" class="field-name">Limit to N comments?</label>
+                            <input id="limit" type="number" placeholder="100" v-model="options.limit">
+                            <span>(1000 is the maximum allowed by Trello)</span>
+                        </div>
+                        <div class="form-field">
+                            <label for="truncationLength" class="field-name">Truncate comments to N lines?</label>
+                            <input id="truncationLength" type="number" placeholder="5" v-model="options.truncationLength">
+                            <span>(Leave empty to display the full comments)</span>
                         </div>
                         <br>
-                        <button
-                                class="button wide"
-                                :class="{ disabled: isSubmitButtonDisabled }"
-                                :disabled="isSubmitButtonDisabled"
-                                @click="fetchComments()"
-                        >
-                            <template v-if="loading">Fetching comments...</template>
-                            <template v-else>Fetch comments</template>
-                        </button>
+                        <div class="form-field">
+                            <input id="excludeScopes" type="checkbox" v-model="options.excludedBoards.scopes">
+                            <label for="excludeScopes" class="field-name">Exclude <em>Scopes</em> board?</label>
+                        </div>
                         <br>
-
-                        <template v-if="error">
-                            An error occurred: <strong>{{ error }}</strong>
-                            <br>
-                            <template v-if="error.includes('404')">
-                                The username you entered may be incorrect.
-                            </template>
-                            <template v-else-if="error.includes('401')">
-                                The identifier or token you entered may be incorrect.
-                            </template>
-                        </template>
-
-                        <div v-if="comments">
-                            <h2>Results ({{ filteredComments.length }} comments found)</h2>
-
-                            <input id="search" type="text" placeholder="Filter results" v-model="search">
-                            <hr>
-
-                            <table>
-                                <thead>
-                                    <tr>
-                                        <th class="column-date">
-                                            Date
-                                            <div class="sorting-arrows">
-                                                <span @click="updateSort({ field: 'date', ascending: true })">⬆️</span>
-                                                <span @click="updateSort({ field: 'date', ascending: false })">⬇️</span>
-                                            </div>
-                                        </th>
-                                        <th class="column-card">
-                                            Board
-                                            <div class="sorting-arrows">
-                                                <span @click="updateSort({ field: 'board', ascending: true })">⬆️</span>
-                                                <span @click="updateSort({ field: 'board', ascending: false })">⬇️</span>
-                                            </div>
-                                        </th>
-                                        <th class="column-card">
-                                            Card
-                                            <div class="sorting-arrows">
-                                                <span @click="updateSort({ field: 'card', ascending: true })">⬆️</span>
-                                                <span @click="updateSort({ field: 'card', ascending: false })">⬇️</span>
-                                            </div>
-                                        </th>
-                                        <th class="column-comment">Comment</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr v-for="comment in filteredComments">
-                                        <td>{{ comment.date }}</td>
-                                        <td>{{ comment.board }}</td>
-                                        <td><a :href="comment.link" target="_blank">{{ comment.card }}</a></td>
-                                        <td class="rendered-markdown" v-html="comment.text"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
+                        <div class="form-field">
+                            <input id="excludeHRCUPaths" type="checkbox" v-model="options.excludedBoards.HRCUPaths">
+                            <label for="excludeHRCUPaths" class="field-name">Exclude <em>HR: CU Paths</em> board?</label>
+                        </div>
+                        <br>
+                        <div class="form-field">
+                            <input id="excludeZConvexity" type="checkbox" v-model="options.excludedBoards.zConvexity">
+                            <label for="excludeZConvexity" class="field-name">Exclude <em>zConvexity</em> boards?</label>
                         </div>
                     </div>
                     <br>
+                    <button
+                            class="button wide"
+                            :class="{ disabled: isSubmitButtonDisabled }"
+                            :disabled="isSubmitButtonDisabled"
+                            @click="fetchComments()"
+                    >
+                        <template v-if="loading">Fetching comments...</template>
+                        <template v-else>Fetch comments</template>
+                    </button>
+                    <br>
+
+                    <template v-if="error">
+                        An error occurred: <strong>{{ error }}</strong>
+                        <br>
+                        <template v-if="error.includes('404')">
+                            The username you entered may be incorrect.
+                        </template>
+                        <template v-else-if="error.includes('401')">
+                            The identifier or token you entered may be incorrect.
+                        </template>
+                    </template>
+
+                    <div v-if="comments">
+                        <h2>Results ({{ filteredComments.length }} comments found)</h2>
+
+                        <input id="search" type="text" placeholder="Filter results" v-model="search">
+                        <hr>
+
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th class="column-date">
+                                        Date
+                                        <div class="sorting-arrows">
+                                            <span @click="updateSort({ field: 'date', ascending: true })">⬆️</span>
+                                            <span @click="updateSort({ field: 'date', ascending: false })">⬇️</span>
+                                        </div>
+                                    </th>
+                                    <th class="column-card">
+                                        Board
+                                        <div class="sorting-arrows">
+                                            <span @click="updateSort({ field: 'board', ascending: true })">⬆️</span>
+                                            <span @click="updateSort({ field: 'board', ascending: false })">⬇️</span>
+                                        </div>
+                                    </th>
+                                    <th class="column-card">
+                                        Card
+                                        <div class="sorting-arrows">
+                                            <span @click="updateSort({ field: 'card', ascending: true })">⬆️</span>
+                                            <span @click="updateSort({ field: 'card', ascending: false })">⬇️</span>
+                                        </div>
+                                    </th>
+                                    <th class="column-comment">Comment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr v-for="comment in filteredComments">
+                                    <td>{{ comment.date }}</td>
+                                    <td>{{ comment.board }}</td>
+                                    <td><a :href="comment.link" target="_blank">{{ comment.card }}</a></td>
+                                    <td class="rendered-markdown" v-html="comment.text"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
+                <br>
             </div>
         </div>
 

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -62,6 +62,11 @@
                                 <input id="limit" type="number" placeholder="100" v-model="options.limit">
                                 <span>(1000 is the maximum allowed by Trello)</span>
                             </div>
+                            <div class="form-field">
+                                <label for="truncationLength" class="field-name">Truncate comments to N lines?</label>
+                                <input id="truncationLength" type="number" placeholder="5" v-model="options.truncationLength">
+                                <span>(Leave empty to display the full comments)</span>
+                            </div>
                             <br>
                             <div class="form-field">
                                 <input id="excludeScopes" type="checkbox" v-model="options.excludedBoards.scopes">

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -102,7 +102,7 @@
                                         <td>{{ comment.date }}</td>
                                         <td>{{ comment.board }}</td>
                                         <td><a :href="comment.link" target="_blank">{{ comment.card }}</a></td>
-                                        <td v-html="comment.text"></td>
+                                        <td class="rendered-markdown" v-html="comment.text"></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -115,6 +115,7 @@
 
         <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/12.3.2/markdown-it.min.js"></script>
         <script src="./scripts/trello/api.js"></script>
         <script src="./scripts/trello/actions.js"></script>
         <script src="./scripts/trelloCommentsDashboard.js"></script>

--- a/trelloOnboardingBuilder.html
+++ b/trelloOnboardingBuilder.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" type="text/css" href="./style/style.css">
 </head>
 <body>
-<div>
 <div id="app">
     <div id="header">
         <div class="container">
@@ -68,7 +67,6 @@
         </div>
         <br>
     </div>
-</div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>


### PR DESCRIPTION
Issue:
- #15

# Context 

Flavien introduced his _MAgic PERformance Review Method_ (MAPERM) in this course: https://team.360learning.com/course/play/60e4664e08a16a9045addcbd

Key part:

> The MAPERM’s secret is to make a detailed assessment of each interaction, even the most insignificant one. There are two steps to achieve this:
-list all interactions;
-for each interaction, assess it.

Unfortunately, Trello's interface makes it really difficult to gather all the messages of a given person during some time period.
I figured it would be useful to use the Trello API to do that and display the results in a basic table.

We already have a `github.io` page with 2 tools: https://360learning.github.io/index.html
- A tool to generate a signature for mails
- A tool to automate the setup of onboarding boards

In this PR, I add a 3rd one: the Trello comments dashboard.

<img width="986" alt="image" src="https://user-images.githubusercontent.com/51365591/164267997-e46d868e-1809-4d89-bf6f-b3f4776ce93f.png">


# Changes

- Add a new `trelloCommentsDashboard` tool, drawing inspiration from [Adrien's Trello board building helper](https://360learning.github.io/trelloOnboardingBuilder.html)
- Create the main fields of the form (Trello identifier, auth token, the reviewee's Trello username)
- Create a function that fetches a user's comments via the Trello API
- Display the results in a table
- Add sorting on the table's columns
- Add options to refine the results (date range, number of results, exclude some boards)