### PR TITLE
master(17): Trello comments dashboard - Export results as CSV

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,15 +15,17 @@
         </div>
         <div class="element container">
             <h1>List of tools</h1>
-            <button onclick="location.href='signatureGenerator.html'" class="tool">
-                Signature Generator
-            </button>
-            <button onclick="location.href='trelloOnboardingBuilder.html'" class="tool">
-                Trello board building helper for new joiners
-            </button>
-            <button onclick="location.href='trelloCommentsDashboard.html'" class="tool">
-                Trello comments dashboard
-            </button>
+            <ul>
+                <li>
+                    <a href="signatureGenerator.html">Signature Generator</a>
+                </li>
+                <li>
+                    <a href="trelloOnboardingBuilder.html">Trello board building helper for new joiners</a>
+                </li>
+                <li>
+                    <a href="trelloCommentsDashboard.html">Trello comments dashboard</a>
+                </li>
+            </ul>
         </div>
     </div>
 </div>

--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -1,5 +1,6 @@
 const TRELLO_BASE_URL = "https://trello.com";
 const TRELLO_CREDENTIALS_HELPER_FILE = "https://docs.google.com/document/d/1HwaedNa861gkj93TaradW5n0MID8cbeamiU5SXCvX64/edit#heading=h.ijjo2dol5z6v"
+const GOOGLE_SHEETS_EXPORT_TEMPLATE = "https://docs.google.com/spreadsheets/d/1gAbqE94JWzFgeq6Q7DwCjlTb7NQtsIEzCtOS8pyFBBA/edit#gid=0"
 const SCOPES_BOARD_NAME = "2. Scopes";
 const HR_CU_PATHS_BOARD_NAME = "HR: CU Paths";
 const ZCONVEXITY_BOARDS_PREFIX = "zConvexity";
@@ -24,6 +25,7 @@ new Vue({
         search: "",
         sort: { field: "date", ascending: false },
         trelloCredentialsHelperFile: TRELLO_CREDENTIALS_HELPER_FILE,
+        googleSheetsExportTemplate: GOOGLE_SHEETS_EXPORT_TEMPLATE,
         credentials: {
             trelloApiKey: "",
             trelloOAuth1: ""

--- a/style/style.css
+++ b/style/style.css
@@ -32,11 +32,6 @@ html, body
     flex-direction: column;
 }
 
-.tool
-{
-    margin-bottom: 16px;
-}
-
 .element
 {
     border-radius: 4px;

--- a/style/style.css
+++ b/style/style.css
@@ -106,12 +106,12 @@ input:focus, select:focus
     border: 1px solid #9e9e9e;
 }
 
-button, .wide
+button.wide
 {
     width: 400px;
 }
 
-button, .with-margin
+button.with-margin
  {
      margin: 8px auto !important;
  }

--- a/style/style.css
+++ b/style/style.css
@@ -58,15 +58,13 @@ html, body
     margin: 4px 0;
 }
 
-.form a
-{
+a {
     color: #00A0FF;
     font-weight: bold;
     text-decoration: none;
 }
 
-.form a:hover
-{
+a:hover {
     text-decoration: underline;
 }
 

--- a/style/trelloCommentsDashboard.css
+++ b/style/trelloCommentsDashboard.css
@@ -2,6 +2,11 @@
     flex-direction: column;
 }
 
+.results-toolbar {
+    display: flex;
+    justify-content: space-between;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -108,7 +108,11 @@
                     <div v-if="comments">
                         <h2>Results ({{ filteredComments.length }} comments found)</h2>
 
-                        <input id="search" type="text" placeholder="Filter results" v-model="search">
+                        <div class="results-toolbar">
+                            <input id="search" type="text" placeholder="Filter results" v-model="search">
+                            <button @click="copyCsvToClipboard()">Copy as CSV to clipboard</button>
+                            <button @click="downloadCsvFile()">Download as CSV</button>
+                        </div>
                         <hr>
 
                         <table>

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -108,6 +108,13 @@
                     <div v-if="comments">
                         <h2>Results ({{ filteredComments.length }} comments found)</h2>
 
+                        💡 If you want to keep a trace of these results or analyze them further, you can make a copy of this <a :href="googleSheetsExportTemplate">Google Sheets template</a>.
+                        <ul>
+                            <li>Copy the comments to the clipboard using the button below</li>
+                            <li>Select the first cell of the spreadsheet</li>
+                            <li>Paste the comments (Cmd / Ctrl + V), and voilà ✨</li>
+                        </ul>
+
                         <div class="results-toolbar">
                             <input id="search" type="text" placeholder="Filter results" v-model="search">
                             <button @click="copyCsvToClipboard()">Copy as CSV to clipboard</button>


### PR DESCRIPTION
Issue:

- #17

## Context

In https://github.com/360Learning/360learning.github.io/pull/16, I created a page to visualize the Trello comments of a given user on some time period.

This PR adds a CSV export feature, to keep track of the results and enable further analysis.

![](https://user-images.githubusercontent.com/51365591/166145832-bee0a1e7-b5c7-4823-896b-74609ba109e2.png)

## Changes

- Small CSS improvements
- Replace buttons with links in the homepage
- Implement CSV export / copy to clipboard of the filtered comments
- Add a link to a Google Sheets template to make lives of 360Learners easier (they'll just have to click "copy to clipboard" and paste the results in the sheet)