### PR TITLE
Rework date fields in Trello comments dashboard

### DIFF
--- a/scripts/trelloCommentsDashboard.js
+++ b/scripts/trelloCommentsDashboard.js
@@ -10,8 +10,8 @@ new Vue({
     data: {
         comments: null,
         options: {
-            before: getStartOfCurrentQuarter(),
-            since: getStartOfPreviousQuarter(),
+            before: undefined,
+            since: undefined,
             limit: 1000,
             excludedBoards: {
                 scopes: true,
@@ -145,13 +145,6 @@ function parseComments(comments, options) {
             link: buildLinkToComment(comment)
         };
     }
-}
-
-function getStartOfPreviousQuarter() {
-    return moment().startOf("quarter").subtract(3, "months").format("YYYY-MM-DD");
-}
-function getStartOfCurrentQuarter() {
-    return moment().startOf("quarter").format("YYYY-MM-DD");
 }
 
 function buildCommentText(markdown, truncationLength) {

--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -48,12 +48,12 @@
 
                         <div class="form-field">
                             <label for="since" class="field-name">Start date</label>
-                            <input id="since" type="date" placeholder="YYYY-MM-DD" v-model="options.since">
+                            <input id="since" type="date" v-model="options.since">
                             <span>(included)</span>
                         </div>
                         <div class="form-field">
                             <label for="before" class="field-name">End date</label>
-                            <input id="before" type="date" placeholder="YYYY-MM-DD" v-model="options.before">
+                            <input id="before" type="date" v-model="options.before">
                             <span>(excluded)</span>
                         </div>
                         <div class="form-field">


### PR DESCRIPTION
Currently, the dates are preselected with the bounds of the previous quarter:

<img width="733" alt="image" src="https://user-images.githubusercontent.com/51365591/190698575-577ef70d-7fe2-451b-aa55-2d0fbfc6b6e5.png">

We thought it was useful because most of the time people will use it for perf reviews.
But it's actually not that convenient, because 
- sometimes people prepare the perf review before the end of the quarter
- we don't use the tool only for that

### Changes

- Don't pre-select dates
- Remove some useless placeholders