### PR TITLE
chore: [360Tools] reword identifier into API key

### DIFF
--- a/trelloCommentsDashboard.html
+++ b/trelloCommentsDashboard.html
@@ -24,7 +24,7 @@
 
                     <hr>
 
-                    <br>To get started, get your <a target="_blank" :href="trelloCredentialsHelperFile">Trello API information</a> and store carefully your identifier and authentication token.
+                    <br>To get started, get your <a target="_blank" :href="trelloCredentialsHelperFile">Trello API information</a> and make sure to have your API key and authentication token.
                     <br>This tool will fetch your colleague's Trello comments on your behalf.
                     <br>Don't worry, the information will not be stored by this website in any way.
 
@@ -32,7 +32,7 @@
 
                     <div class="form-wrapper direction-column">
                         <div class="form-field">
-                            <label for="trelloApiKey" class="field-name">Trello identifier:</label>
+                            <label for="trelloApiKey" class="field-name">Trello API key:</label>
                             <input id="trelloApiKey" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd" v-model="credentials.trelloApiKey">
                         </div>
                         <div class="form-field">

--- a/trelloOnboardingBuilder.html
+++ b/trelloOnboardingBuilder.html
@@ -18,7 +18,7 @@
             <p>Are you preparing a new padawan's arrival? Great, let's help you!</p>
             <ol>
                 <li>First, ensure you already created their board.</li>
-                <li>Then <a target="_blank" href="https://docs.google.com/document/d/1HwaedNa861gkj93TaradW5n0MID8cbeamiU5SXCvX64/edit#heading=h.ijjo2dol5z6v">get your Trello API information</a> and store carefully your identifier and authentication token.</li>
+                <li>Then <a target="_blank" href="https://docs.google.com/document/d/1HwaedNa861gkj93TaradW5n0MID8cbeamiU5SXCvX64/edit#heading=h.ijjo2dol5z6v">get your Trello API information</a> and make sure to have your API key and authentication token.</li>
                 <li>Go on to the following steps.</li>
                 <li>And enjoy!</li>
             </ol>
@@ -30,7 +30,7 @@
             </p>
             <div class="form-wrapper">
                 <div class="form-field">
-                    <label for="trelloApiKey" class="field-name">Trello identifier :</label>
+                    <label for="trelloApiKey" class="field-name">Trello API Key :</label>
                     <input id="trelloApiKey" type="text" placeholder="1234abcd1234abcd1234abcd1234abcd" v-model="trelloApiKey">
                 </div>
                 <div class="form-field">


### PR DESCRIPTION
Context : https://trello.com/c/Xmm2hMaP/578-trello-comments-retrieving-tool

In both 360Tools [comments dashboard](https://360learning.github.io/trelloCommentsDashboard.html) and [onboarding dashboard](https://360learning.github.io/trelloOnboardingBuilder.html), the "Trello identifier" wording can be misleading, since it is not the identifier (eg `martinbocconbelloni1`) that is expected but the API key.

Before:
<img width="618" alt="Capture d’écran 2023-10-10 à 17 20 15" src="https://github.com/360Learning/360learning.github.io/assets/112958701/11609d5a-54cb-438a-afd1-d821992870e1">
After:
<img width="612" alt="Capture d’écran 2023-10-10 à 17 20 24" src="https://github.com/360Learning/360learning.github.io/assets/112958701/558cddec-54b4-42fb-b33a-4fa296b738dc">
